### PR TITLE
Clarify donation confirmation and net payout

### DIFF
--- a/src/features/campaigns/components/DonationCard.tsx
+++ b/src/features/campaigns/components/DonationCard.tsx
@@ -64,6 +64,9 @@ import {
 } from "./modals/BadgeRewardModal";
 import { ShareModal } from "./modals/ShareModal";
 
+const BPS_DENOMINATOR = 10_000n;
+const PLATFORM_FEE_BPS = 500n;
+
 interface DonationCardProps {
   campaignId: string;
   statsId: string;
@@ -738,8 +741,26 @@ export function DonationCard({
         6,
       );
 
+      const netRawAmount =
+        ((amountRawFromEvent ?? rawAmount) *
+          (BPS_DENOMINATOR - PLATFORM_FEE_BPS)) /
+        BPS_DENOMINATOR;
+      const netAmountHuman = formatRawAmount(
+        netRawAmount,
+        selectedToken.decimals,
+        6,
+      );
+
       const usdDisplay = amountUsdMicro
         ? `$${formatUsdLocaleFromMicros(amountUsdMicro)}`
+        : null;
+
+      const netUsdMicro = amountUsdMicro
+        ? (amountUsdMicro * (BPS_DENOMINATOR - PLATFORM_FEE_BPS)) /
+          BPS_DENOMINATOR
+        : null;
+      const netUsdDisplay = netUsdMicro
+        ? `$${formatUsdLocaleFromMicros(netUsdMicro)}`
         : null;
 
       const parts = [
@@ -757,9 +778,11 @@ export function DonationCard({
       const explorerUrl = buildExplorerTxUrl(transactionDigest, network);
       setSuccessReceipt({
         amountDisplay: amountHuman,
+        netAmountDisplay: netAmountHuman,
         tokenSymbol: selectedToken.symbol,
         tokenLabel: selectedTokenDisplay?.label ?? selectedToken.symbol,
         approxUsdDisplay: usdDisplay,
+        netApproxUsdDisplay: netUsdDisplay,
         explorerUrl,
         transactionDigest,
         TokenIcon: selectedTokenDisplay?.Icon ?? null,

--- a/src/features/campaigns/components/modals/DonationProcessingModal.tsx
+++ b/src/features/campaigns/components/modals/DonationProcessingModal.tsx
@@ -28,8 +28,20 @@ export function DonationProcessingModal({
   onCancel,
   onConfirm,
 }: DonationProcessingModalProps) {
-  const confirmLabel = hasAttemptedConfirmation ? "Try again" : "Confirm";
-  const confirmDisabled = isBuilding || isWalletRequestPending || !canConfirm;
+  const awaitingWallet = isWalletRequestPending;
+  const confirmLabel = awaitingWallet
+    ? "Waiting for wallet"
+    : hasAttemptedConfirmation
+      ? "Try again"
+      : "Confirm";
+  const confirmDisabled = isBuilding || awaitingWallet || !canConfirm;
+
+  const title = awaitingWallet
+    ? "Waiting for wallet approval"
+    : "Confirm transaction";
+  const description = awaitingWallet
+    ? "Approve the transaction in your wallet to continue."
+    : "Please confirm transaction from your wallet";
 
   return (
     <Dialog
@@ -44,10 +56,10 @@ export function DonationProcessingModal({
 
           <div className="flex flex-col gap-2">
             <DialogTitle className="text-2xl font-semibold text-black-500">
-              Confirm transaction
+              {title}
             </DialogTitle>
             <DialogDescription className="text-sm text-black-300">
-              Please confirm transaction from your wallet
+              {description}
             </DialogDescription>
           </div>
         </div>
@@ -65,7 +77,7 @@ export function DonationProcessingModal({
             onClick={onConfirm}
             disabled={confirmDisabled}
           >
-            {isWalletRequestPending ? (
+            {awaitingWallet ? (
               <span className="flex items-center justify-center gap-2 text-sm font-semibold">
                 <Loader2 className="size-4 animate-spin" />
                 {confirmLabel}

--- a/src/features/campaigns/components/modals/DonationSuccessModal.tsx
+++ b/src/features/campaigns/components/modals/DonationSuccessModal.tsx
@@ -14,9 +14,11 @@ const SUCCESS_ICON = "/assets/images/modal-icons/modal-donation-success.png";
 
 export interface DonationReceiptSummary {
   amountDisplay: string;
+  netAmountDisplay?: string;
   tokenSymbol: string;
   tokenLabel: string;
   approxUsdDisplay?: string | null;
+  netApproxUsdDisplay?: string | null;
   explorerUrl?: string | null;
   transactionDigest: string;
   TokenIcon?: ComponentType<{ className?: string }> | null;
@@ -36,10 +38,12 @@ export function DonationSuccessModal({
   onViewContributions,
 }: DonationSuccessModalProps) {
   const canViewContributions = Boolean(onViewContributions);
-  const netAmount = receipt?.amountDisplay ?? "--";
+  const netAmount =
+    receipt?.netAmountDisplay ?? receipt?.amountDisplay ?? "--";
   const tokenSymbol = receipt?.tokenSymbol ?? "";
 
-  const approxUsd = receipt?.approxUsdDisplay ?? null;
+  const approxUsd =
+    receipt?.netApproxUsdDisplay ?? receipt?.approxUsdDisplay ?? null;
   const TokenIcon = receipt?.TokenIcon ?? null;
   const explorerHref = receipt?.explorerUrl ?? null;
 


### PR DESCRIPTION
## Summary
- clarify the donation confirmation modal to reflect when the wallet approval is pending
- compute net donation amounts after the platform fee and surface them in the success modal

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295858f494832dbaf902b70525abab)