### PR TITLE
Enforce campaign social link requirements and stabilize Walrus editing flow

### DIFF
--- a/src/features/campaigns/components/new-campaign/CampaignSocialsSection.tsx
+++ b/src/features/campaigns/components/new-campaign/CampaignSocialsSection.tsx
@@ -10,6 +10,11 @@ import {
   MAX_SOCIAL_LINKS,
   SOCIAL_PLATFORM_CONFIG,
 } from "@/features/campaigns/constants/socialPlatforms";
+import {
+  CAMPAIGN_SOCIAL_LINKS_MIN_ERROR,
+  getCompletedSocialLinksCount,
+} from "@/features/campaigns/utils/socials";
+import { cn } from "@/shared/lib/utils";
 import { Button } from "@/shared/components/ui/button";
 import { Input } from "@/shared/components/ui/input";
 import {
@@ -24,6 +29,7 @@ interface CampaignSocialsSectionProps {
   disabled?: boolean;
   labelAction?: ReactNode;
   labelStatus?: ReactNode;
+  minSocials?: number;
   maxSocials?: number;
 }
 
@@ -40,6 +46,7 @@ export function CampaignSocialsSection({
   disabled = false,
   labelAction,
   labelStatus,
+  minSocials = 0,
   maxSocials = MAX_SOCIAL_LINKS,
 }: CampaignSocialsSectionProps) {
   const {
@@ -53,17 +60,30 @@ export function CampaignSocialsSection({
   });
 
   const socials = watch("socials");
-  const socialCount = socials?.length ?? 0;
-  const isAtLimit = socialCount >= maxSocials;
+  const socialRows = socials?.length ?? 0;
+  const completedSocialCount = getCompletedSocialLinksCount(socials ?? []);
+  const isAtMinimum = socialRows <= minSocials;
+  const isAtLimit = socialRows >= maxSocials;
+  const isBelowMinimum = minSocials > 0 && completedSocialCount < minSocials;
+  const socialSectionError = !Array.isArray(errors.socials)
+    ? (errors.socials as FieldError | undefined)?.message
+    : undefined;
+  const helperMessage = socialSectionError
+    ? String(socialSectionError)
+    : isBelowMinimum
+      ? CAMPAIGN_SOCIAL_LINKS_MIN_ERROR
+      : isAtLimit
+        ? `You have reached the maximum of ${maxSocials} social links.`
+        : minSocials > 0
+          ? `At least ${minSocials} valid social links are required. You can add up to ${maxSocials} total.`
+          : `You can add up to ${maxSocials} social links.`;
 
   useEffect(() => {
     // Keep field array in sync with async resets/navigation to avoid blank rows.
     if (!Array.isArray(socials)) {
       return;
     }
-    const normalized = socials.filter(
-      (entry) => entry && entry.platform,
-    );
+    const normalized = socials.filter((entry) => entry && entry.platform);
     if (
       normalized.length !== socials.length ||
       normalized.length !== fields.length
@@ -116,7 +136,10 @@ export function CampaignSocialsSection({
                       onValueChange={controllerField.onChange}
                       disabled={disabled}
                     >
-                      <SelectTrigger className="w-full sm:w-40" disabled={disabled}>
+                      <SelectTrigger
+                        className="w-full sm:w-40"
+                        disabled={disabled}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -163,9 +186,9 @@ export function CampaignSocialsSection({
                   </div>
                   <button
                     type="button"
-                    onClick={() => !disabled && remove(index)}
+                    onClick={() => !disabled && !isAtMinimum && remove(index)}
                     className="shrink-0 size-5 flex items-center justify-center text-red-300 hover:text-red-400 transition-colors mt-3 disabled:opacity-50"
-                    disabled={disabled}
+                    disabled={disabled || isAtMinimum}
                   >
                     <X className="size-[15.417px]" />
                   </button>
@@ -186,10 +209,15 @@ export function CampaignSocialsSection({
           <Plus className="size-[13.25px]" />
           Add more
         </Button>
-        <p className="text-xs text-muted-foreground">
-          {isAtLimit
-            ? `You have added the maximum of ${maxSocials} social links.`
-            : `You can add up to ${maxSocials} social links (${socialCount}/${maxSocials}).`}
+        <p
+          className={cn(
+            "text-xs",
+            isBelowMinimum || socialSectionError
+              ? "font-medium text-destructive"
+              : "text-muted-foreground",
+          )}
+        >
+          {helperMessage}
         </p>
       </div>
     </div>

--- a/src/features/campaigns/constants/socialPlatforms.ts
+++ b/src/features/campaigns/constants/socialPlatforms.ts
@@ -62,4 +62,5 @@ export const SOCIAL_PLATFORM_KEYS = Object.keys(
   SOCIAL_PLATFORM_CONFIG,
 ) as SocialPlatform[];
 
+export const MIN_CAMPAIGN_SOCIAL_LINKS = 2;
 export const MAX_SOCIAL_LINKS = 5;

--- a/src/features/campaigns/hooks/useCreateCampaign.ts
+++ b/src/features/campaigns/hooks/useCreateCampaign.ts
@@ -7,7 +7,7 @@
 
 import { useMutation } from "@tanstack/react-query";
 import { useSuiClient } from "@mysten/dapp-kit";
-import type { CampaignFormData } from "@/features/campaigns/types/campaign";
+import type { CampaignWalrusStorageData } from "@/features/campaigns/types/campaign";
 import { DEFAULT_NETWORK } from "@/shared/config/networkConfig";
 
 /**
@@ -23,7 +23,7 @@ export function useEstimateStorageCost() {
       formData,
       epochs,
     }: {
-      formData: CampaignFormData;
+      formData: CampaignWalrusStorageData;
       epochs?: number;
     }) => {
       const { calculateStorageCost } = await import("@/services/walrus");

--- a/src/features/campaigns/hooks/useWalrusUpload.ts
+++ b/src/features/campaigns/hooks/useWalrusUpload.ts
@@ -28,7 +28,7 @@ import {
   buildCertifyTransaction,
   getUploadedFilesInfo,
 } from "@/services/walrus";
-import type { CampaignFormData } from "@/features/campaigns/types/campaign";
+import type { CampaignWalrusStorageData } from "@/features/campaigns/types/campaign";
 import type { CampaignUpdateStorageData } from "@/features/campaigns/types/campaignUpdate";
 import {
   DEFAULT_NETWORK,
@@ -154,7 +154,7 @@ export function useWalrusUpload() {
   type PrepareArgs =
     | {
         purpose?: "campaign";
-        formData: CampaignFormData;
+        formData: CampaignWalrusStorageData;
         update?: undefined;
         avatar?: undefined;
         network?: SupportedNetwork;
@@ -204,13 +204,17 @@ export function useWalrusUpload() {
 
       if (purpose === "campaign") {
         if (!formData) {
-          throw new Error("Campaign form data is required for campaign uploads");
+          throw new Error(
+            "Campaign form data is required for campaign uploads",
+          );
         }
         files = await prepareCampaignFiles(formData);
       } else {
         if (purpose === "campaign-update") {
           if (!update) {
-            throw new Error("Update payload is required for campaign update uploads");
+            throw new Error(
+              "Update payload is required for campaign update uploads",
+            );
           }
           files = await prepareCampaignUpdateFiles(update);
         } else {
@@ -341,7 +345,11 @@ export function useWalrusUpload() {
   /**
    * Step 3: Upload data to Walrus storage nodes (no transaction)
    */
-  const upload = useMutation<WalrusFlowState, Error, { flowState: WalrusFlowState; registerDigest: string }>({
+  const upload = useMutation<
+    WalrusFlowState,
+    Error,
+    { flowState: WalrusFlowState; registerDigest: string }
+  >({
     mutationFn: async ({ flowState, registerDigest }) => {
       await uploadToWalrusNodes(flowState.flow, registerDigest);
       return flowState;

--- a/src/features/campaigns/schemas/newCampaignSchema.ts
+++ b/src/features/campaigns/schemas/newCampaignSchema.ts
@@ -6,23 +6,22 @@ import {
   MAX_FUNDING_TARGET,
   MIN_FUNDING_TARGET,
 } from "@/features/campaigns/constants/funding";
-import { MAX_SOCIAL_LINKS } from "@/features/campaigns/constants/socialPlatforms";
+import {
+  MAX_SOCIAL_LINKS,
+  MIN_CAMPAIGN_SOCIAL_LINKS,
+} from "@/features/campaigns/constants/socialPlatforms";
 import { DESCRIPTION_MAX_LENGTH } from "@/features/campaigns/constants/validation";
+import {
+  CAMPAIGN_SOCIAL_LINKS_MIN_ERROR,
+  getCompletedSocialLinksCount,
+  isValidSocialLinkUrl,
+} from "@/features/campaigns/utils/socials";
 import {
   SUBDOMAIN_MAX_LENGTH,
   SUBDOMAIN_MIN_LENGTH,
   SUBDOMAIN_PATTERN,
 } from "@/shared/utils/subdomain";
 import { parseDateInputAsLocalDate } from "@/shared/utils/dateInput";
-
-const isValidHttpUrl = (value: string) => {
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === "https:" || parsed.protocol === "http:";
-  } catch {
-    return false;
-  }
-};
 
 export const socialSchema = z.object({
   platform: z.string(),
@@ -34,7 +33,7 @@ export const socialSchema = z.object({
       "URL cannot contain spaces",
     )
     .refine(
-      (value) => value === "" || isValidHttpUrl(value),
+      (value) => value === "" || isValidSocialLinkUrl(value),
       "Please enter a valid URL",
     ),
 });
@@ -83,9 +82,7 @@ export const newCampaignSchema = z
       .refine((file) => file.size <= 5 * 1024 * 1024, {
         message: "Image size must be less than 5MB",
       }),
-    campaignType: z
-      .string()
-      .min(1, "Please select a campaign type"),
+    campaignType: z.string().min(1, "Please select a campaign type"),
     categories: z
       .array(z.string())
       .min(1, "Please select at least one category"),
@@ -127,6 +124,14 @@ export const newCampaignSchema = z
       ),
     socials: z
       .array(socialSchema)
+      .superRefine((socials, ctx) => {
+        if (getCompletedSocialLinksCount(socials) < MIN_CAMPAIGN_SOCIAL_LINKS) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: CAMPAIGN_SOCIAL_LINKS_MIN_ERROR,
+          });
+        }
+      })
       .max(MAX_SOCIAL_LINKS, "You can add up to 5 social links."),
     campaignDetails: z
       .string()

--- a/src/features/campaigns/types/campaign.ts
+++ b/src/features/campaigns/types/campaign.ts
@@ -40,6 +40,15 @@ export interface CampaignFormData {
 }
 
 /**
+ * Walrus-backed campaign content only.
+ * This is the subset of campaign data that affects Walrus upload/estimation.
+ */
+export interface CampaignWalrusStorageData {
+  full_description: string;
+  cover_image: File;
+}
+
+/**
  * Metadata structure for the VecMap<String, String> on Sui
  * All values must be strings as per the smart contract
  */
@@ -94,40 +103,40 @@ export interface CreateCampaignResult {
  * Steps in the campaign creation process for progress tracking
  */
 export enum CampaignCreationStep {
-  IDLE = 'idle',
-  VALIDATING = 'validating',
-  PREPARING_FILES = 'preparing_files',
-  UPLOADING_TO_WALRUS = 'uploading_to_walrus',
-  BUILDING_TRANSACTION = 'building_transaction',
-  EXECUTING_TRANSACTION = 'executing_transaction',
-  COMPLETED = 'completed',
-  FAILED = 'failed',
+  IDLE = "idle",
+  VALIDATING = "validating",
+  PREPARING_FILES = "preparing_files",
+  UPLOADING_TO_WALRUS = "uploading_to_walrus",
+  BUILDING_TRANSACTION = "building_transaction",
+  EXECUTING_TRANSACTION = "executing_transaction",
+  COMPLETED = "completed",
+  FAILED = "failed",
 }
 
 /**
  * Main wizard steps for the controlled campaign creation flow
  */
 export enum WizardStep {
-  FORM = 'form',
-  ESTIMATING = 'estimating',
-  CONFIRM_REGISTER = 'confirm_register',  // User confirms buying Walrus storage with WAL
-  REGISTERING = 'registering',            // Registering blob (1st transaction)
-  UPLOADING = 'uploading',                // Uploading data to storage nodes
-  CERTIFYING = 'certifying',              // Certifying blob (2nd transaction)
-  CONFIRM_TX = 'confirm_tx',              // User confirms campaign creation
-  EXECUTING = 'executing',                // Creating campaign (3rd transaction)
-  SUCCESS = 'success',
-  ERROR = 'error',
+  FORM = "form",
+  ESTIMATING = "estimating",
+  CONFIRM_REGISTER = "confirm_register", // User confirms buying Walrus storage with WAL
+  REGISTERING = "registering", // Registering blob (1st transaction)
+  UPLOADING = "uploading", // Uploading data to storage nodes
+  CERTIFYING = "certifying", // Certifying blob (2nd transaction)
+  CONFIRM_TX = "confirm_tx", // User confirms campaign creation
+  EXECUTING = "executing", // Creating campaign (3rd transaction)
+  SUCCESS = "success",
+  ERROR = "error",
 }
 
 /**
  * Granular upload steps for detailed progress tracking
  */
 export enum UploadStep {
-  ENCODING = 'encoding',
-  REGISTERING = 'registering',
-  UPLOADING = 'uploading',
-  CERTIFYING = 'certifying',
+  ENCODING = "encoding",
+  REGISTERING = "registering",
+  UPLOADING = "uploading",
+  CERTIFYING = "certifying",
 }
 
 /**
@@ -146,31 +155,31 @@ export class CampaignCreationError extends Error {
   constructor(
     message: string,
     public step: CampaignCreationStep,
-    public originalError?: unknown
+    public originalError?: unknown,
   ) {
     super(message);
-    this.name = 'CampaignCreationError';
+    this.name = "CampaignCreationError";
   }
 }
 
 export class WalrusUploadError extends CampaignCreationError {
   constructor(message: string, originalError?: unknown) {
     super(message, CampaignCreationStep.UPLOADING_TO_WALRUS, originalError);
-    this.name = 'WalrusUploadError';
+    this.name = "WalrusUploadError";
   }
 }
 
 export class TransactionBuildError extends CampaignCreationError {
   constructor(message: string, originalError?: unknown) {
     super(message, CampaignCreationStep.BUILDING_TRANSACTION, originalError);
-    this.name = 'TransactionBuildError';
+    this.name = "TransactionBuildError";
   }
 }
 
 export class TransactionExecutionError extends CampaignCreationError {
   constructor(message: string, originalError?: unknown) {
     super(message, CampaignCreationStep.EXECUTING_TRANSACTION, originalError);
-    this.name = 'TransactionExecutionError';
+    this.name = "TransactionExecutionError";
   }
 }
 
@@ -179,38 +188,38 @@ export class TransactionExecutionError extends CampaignCreationError {
  */
 export interface StorageCostEstimate {
   // Size information
-  rawSize: number;        // Original file sizes in bytes
-  encodedSize: number;    // Size after Walrus encoding (5x + metadata)
-  metadataSize: number;   // Fixed metadata overhead (64MB)
+  rawSize: number; // Original file sizes in bytes
+  encodedSize: number; // Size after Walrus encoding (5x + metadata)
+  metadataSize: number; // Fixed metadata overhead (64MB)
 
   // Duration
-  epochs: number;         // Storage duration in epochs
+  epochs: number; // Storage duration in epochs
 
   // Costs in WAL tokens (before subsidy)
   storageCostWal: number; // Storage cost (epochs × size)
-  uploadCostWal: number;  // One-time upload/write cost
-  totalCostWal: number;   // Total cost in WAL before subsidy
+  uploadCostWal: number; // One-time upload/write cost
+  totalCostWal: number; // Total cost in WAL before subsidy
 
   // Subsidized costs (what user actually pays)
   subsidizedStorageCost: number; // Storage cost after subsidy
-  subsidizedUploadCost: number;  // Upload cost after subsidy
-  subsidizedTotalCost: number;   // Total cost after subsidy
+  subsidizedUploadCost: number; // Upload cost after subsidy
+  subsidizedTotalCost: number; // Total cost after subsidy
 
   // Subsidy information
-  subsidyRate?: number;   // Subsidy rate (0-1, e.g., 0.80 for 80%)
+  subsidyRate?: number; // Subsidy rate (0-1, e.g., 0.80 for 80%)
 
   // Legacy field for backward compatibility (deprecated)
-  estimatedCost: string;  // Total cost in WAL as string (now shows subsidized cost)
+  estimatedCost: string; // Total cost in WAL as string (now shows subsidized cost)
 
   // Breakdown by file type
   breakdown: {
-    jsonSize: number;     // Size of description.json (Lexical editor state)
-    imagesSize: number;   // Size of cover image
+    jsonSize: number; // Size of description.json (Lexical editor state)
+    imagesSize: number; // Size of cover image
   };
 
   // Pricing information
   pricingTimestamp: number; // When pricing was fetched
-  network: 'testnet' | 'mainnet';
+  network: "testnet" | "mainnet";
 }
 
 /**

--- a/src/features/campaigns/utils/socials.ts
+++ b/src/features/campaigns/utils/socials.ts
@@ -1,5 +1,8 @@
 import { PROFILE_METADATA_REMOVED_VALUE } from "@/features/profiles/constants/metadata";
+import { MIN_CAMPAIGN_SOCIAL_LINKS } from "../constants/socialPlatforms";
 import type { CampaignSocialLink } from "../types/campaign";
+
+type SocialLinkInput = Partial<CampaignSocialLink>;
 
 const SOCIALS_JSON_KEY = "socials_json";
 const DEFAULT_SOCIAL_LINKS: CampaignSocialLink[] = [
@@ -12,27 +15,72 @@ export function getDefaultSocialLinks(): CampaignSocialLink[] {
   return DEFAULT_SOCIAL_LINKS.map((link) => ({ ...link }));
 }
 
+export function isValidSocialLinkUrl(value: string): boolean {
+  if (!value || /\s/.test(value)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Normalize and filter social links for storage.
  */
 export function sanitizeSocialLinks(
-  links: CampaignSocialLink[],
+  links: SocialLinkInput[],
 ): CampaignSocialLink[] {
   return links
     .map((link) => {
       const platform = (link.platform ?? "").trim().toLowerCase();
       const url = (link.url ?? "").trim();
-      return platform && url ? { platform, url } : null;
+      return platform && isValidSocialLinkUrl(url) ? { platform, url } : null;
     })
     .filter((link): link is CampaignSocialLink => link !== null);
+}
+
+export const CAMPAIGN_SOCIAL_LINKS_MIN_ERROR = `Add at least ${MIN_CAMPAIGN_SOCIAL_LINKS} valid social links. Empty or invalid links do not count.`;
+
+export function getCompletedSocialLinksCount(links: SocialLinkInput[]): number {
+  return sanitizeSocialLinks(links).length;
+}
+
+export function sanitizeCampaignSocialLinks(
+  links: SocialLinkInput[],
+): CampaignSocialLink[] {
+  const sanitizedLinks = sanitizeSocialLinks(links);
+
+  if (sanitizedLinks.length < MIN_CAMPAIGN_SOCIAL_LINKS) {
+    throw new Error(CAMPAIGN_SOCIAL_LINKS_MIN_ERROR);
+  }
+
+  return sanitizedLinks;
+}
+
+export function normalizeCampaignSocialsMetadataValue(value: string): string {
+  try {
+    const parsed = JSON.parse(value);
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(CAMPAIGN_SOCIAL_LINKS_MIN_ERROR);
+    }
+
+    return JSON.stringify(
+      sanitizeCampaignSocialLinks(parsed as CampaignSocialLink[]),
+    );
+  } catch {
+    throw new Error(CAMPAIGN_SOCIAL_LINKS_MIN_ERROR);
+  }
 }
 
 /**
  * Serialize social links into a JSON string for metadata storage.
  */
-export function serializeSocialLinks(
-  links: CampaignSocialLink[],
-): string {
+export function serializeSocialLinks(links: CampaignSocialLink[]): string {
   return JSON.stringify(sanitizeSocialLinks(links));
 }
 

--- a/src/features/campaigns/utils/transformFormData.ts
+++ b/src/features/campaigns/utils/transformFormData.ts
@@ -6,7 +6,7 @@
 
 import type { NewCampaignFormData } from "../schemas/newCampaignSchema";
 import type { CampaignFormData } from "../types/campaign";
-import { sanitizeSocialLinks } from "./socials";
+import { sanitizeCampaignSocialLinks } from "./socials";
 import { parseDateInputAsLocalDate } from "@/shared/utils/dateInput";
 
 /**
@@ -21,9 +21,9 @@ import { parseDateInputAsLocalDate } from "@/shared/utils/dateInput";
  * - Lexical JSON string for campaign details (already in correct format)
  */
 export function transformNewCampaignFormData(
-  formData: NewCampaignFormData
+  formData: NewCampaignFormData,
 ): CampaignFormData {
-  const socials = sanitizeSocialLinks(formData.socials);
+  const socials = sanitizeCampaignSocialLinks(formData.socials);
   const policyPresetName = formData.campaignType?.trim();
   if (!policyPresetName) {
     throw new Error("Please select a campaign policy preset.");

--- a/src/pages/CreateProfilePage.tsx
+++ b/src/pages/CreateProfilePage.tsx
@@ -1258,7 +1258,6 @@ export default function CreateProfilePage() {
                       render={() => (
                         <FormItem className="flex flex-col gap-2">
                           <CampaignSocialsSection disabled={isFormReadOnly} />
-                          <FormMessage />
                         </FormItem>
                       )}
                     />

--- a/src/pages/EditCampaignPage.tsx
+++ b/src/pages/EditCampaignPage.tsx
@@ -37,15 +37,18 @@ import {
   type EditCampaignFormData,
 } from "@/features/campaigns/schemas/editCampaignSchema";
 import { transformEditCampaignFormData } from "@/features/campaigns/utils/transformEditCampaignFormData";
-import { sanitizeSocialLinks } from "@/features/campaigns/utils/socials";
 import type { CampaignSocialLink } from "@/features/campaigns/types/campaign";
+import type { CampaignWalrusStorageData } from "@/features/campaigns/types/campaign";
 import {
   mapCampaignError,
   extractMoveAbortCode,
 } from "@/features/campaigns/utils/errorMapping";
 import { getContractConfig, CLOCK_OBJECT_ID } from "@/shared/config/contracts";
 import { fetchWalrusBlob } from "@/services/walrus";
-import { DEFAULT_NETWORK, WALRUS_EPOCH_CONFIG } from "@/shared/config/networkConfig";
+import {
+  DEFAULT_NETWORK,
+  WALRUS_EPOCH_CONFIG,
+} from "@/shared/config/networkConfig";
 import { ROUTES } from "@/shared/config/routes";
 import { buildCampaignDetailPath } from "@/shared/utils/routes";
 import {
@@ -58,6 +61,7 @@ import {
   CampaignResolutionMissing,
   CampaignResolutionNotFound,
 } from "@/features/campaigns/components/CampaignResolutionStates";
+import { MIN_CAMPAIGN_SOCIAL_LINKS } from "@/features/campaigns/constants/socialPlatforms";
 import { DEFAULT_POLICY_PRESET } from "@/features/campaigns/constants/policies";
 import {
   DESCRIPTION_MAX_LENGTH,
@@ -618,13 +622,6 @@ export default function EditCampaignPage() {
     const runEstimation = async () => {
       const values = form.getValues();
 
-      const { metadataPatch } = transformEditCampaignFormData({
-        values,
-        dirtyFields,
-        campaign,
-        initialDescription,
-      });
-
       let coverImageFile: File | null = null;
       if (values.coverImage instanceof File) {
         coverImageFile = values.coverImage;
@@ -636,25 +633,9 @@ export default function EditCampaignPage() {
         return;
       }
 
-      const sanitizedSocials = sanitizeSocialLinks(values.socials);
-      const policyPresetName =
-        values.campaignType ||
-        campaign.policyPresetName ||
-        DEFAULT_POLICY_PRESET;
-
-      const walrusFormData = {
-        name: campaign.name,
-        short_description: values.description,
-        subdomain_name: campaign.subdomainName,
-        category: metadataPatch.category ?? campaign.category ?? "",
-        policyPresetName,
-        funding_goal: campaign.fundingGoal ?? "0",
-        start_date: new Date(campaign.startDateMs),
-        end_date: new Date(campaign.endDateMs),
-        recipient_address: campaign.recipientAddress,
+      const walrusFormData: CampaignWalrusStorageData = {
         full_description: values.campaignDetails ?? "",
         cover_image: coverImageFile,
-        socials: sanitizedSocials,
       };
 
       try {
@@ -715,9 +696,8 @@ export default function EditCampaignPage() {
         attempt < CAMPAIGN_PROPAGATION_ATTEMPTS;
         attempt++
       ) {
-        let detail: Awaited<
-          ReturnType<typeof refetchCampaign>
-        >["data"] = undefined;
+        let detail: Awaited<ReturnType<typeof refetchCampaign>>["data"] =
+          undefined;
 
         try {
           const result = await refetchCampaign();
@@ -941,7 +921,20 @@ export default function EditCampaignPage() {
   const categoriesDirty = isEditFieldDirty(dirtyFields, "categories");
   const socialsDirty = isEditFieldDirty(dirtyFields, "socials");
 
-  const mediaSectionDisabled = isWalrusError || isWalrusImageError;
+  const isWalrusDescriptionPending =
+    Boolean(campaignData.descriptionUrl) &&
+    walrusDescriptionQuery.isFetching &&
+    walrusDescriptionQuery.dataUpdatedAt === 0;
+  const isWalrusImagePending =
+    Boolean(campaignData.coverImageUrl) &&
+    walrusCoverImageQuery.isFetching &&
+    walrusCoverImageQuery.dataUpdatedAt === 0;
+  const mediaSectionDisabled =
+    !initialized ||
+    isWalrusDescriptionPending ||
+    isWalrusImagePending ||
+    isWalrusError ||
+    isWalrusImageError;
   const walrusWarningVisible =
     (isWalrusError || isWalrusImageError) && !walrusErrorAcknowledged;
 
@@ -1002,17 +995,13 @@ export default function EditCampaignPage() {
     }
 
     const values = form.getValues();
-    const {
-      metadataPatch,
-      coverImageChanged,
-      descriptionChanged,
-      storageEpochsChanged,
-    } = transformEditCampaignFormData({
-      values,
-      dirtyFields,
-      campaign: campaignData,
-      initialDescription,
-    });
+    const { coverImageChanged, descriptionChanged, storageEpochsChanged } =
+      transformEditCampaignFormData({
+        values,
+        dirtyFields,
+        campaign: campaignData,
+        initialDescription,
+      });
 
     const walrusChanges =
       coverImageChanged || descriptionChanged || storageEpochsChanged;
@@ -1051,25 +1040,9 @@ export default function EditCampaignPage() {
         return;
       }
 
-      const sanitizedSocials = sanitizeSocialLinks(values.socials);
-      const policyPresetName =
-        values.campaignType ||
-        campaignData.policyPresetName ||
-        DEFAULT_POLICY_PRESET;
-
-      const walrusFormData = {
-        name: campaignData.name,
-        short_description: values.description,
-        subdomain_name: campaignData.subdomainName,
-        category: metadataPatch.category ?? campaignData.category ?? "",
-        policyPresetName,
-        funding_goal: campaignData.fundingGoal ?? "0",
-        start_date: new Date(campaignData.startDateMs),
-        end_date: new Date(campaignData.endDateMs),
-        recipient_address: campaignData.recipientAddress,
+      const walrusFormData: CampaignWalrusStorageData = {
         full_description: values.campaignDetails ?? "",
         cover_image: coverImageFile,
-        socials: sanitizedSocials,
       };
 
       const estimate = await estimateStorageCost({
@@ -1694,7 +1667,10 @@ export default function EditCampaignPage() {
         <div className="container px-4 flex justify-center">
           <div className="w-full max-w-3xl px-4">
             <Form {...form}>
-              <form className="flex flex-col gap-16" onSubmit={handleSubmitWithWarning}>
+              <form
+                className="flex flex-col gap-16"
+                onSubmit={handleSubmitWithWarning}
+              >
                 <div className="flex flex-col items-center text-center gap-4">
                   <h1 className="text-5xl font-bold">
                     Edit{" "}
@@ -1811,9 +1787,7 @@ export default function EditCampaignPage() {
                         </FormControl>
                         <div
                           className={`flex items-center text-xs ${
-                            fieldState.error
-                              ? "justify-between"
-                              : "justify-end"
+                            fieldState.error ? "justify-between" : "justify-end"
                           }`}
                         >
                           <FormMessage className="text-xs" />
@@ -1966,6 +1940,7 @@ export default function EditCampaignPage() {
                       <FormItem data-field-error="socials">
                         <CampaignSocialsSection
                           disabled={!editingSections.socials}
+                          minSocials={MIN_CAMPAIGN_SOCIAL_LINKS}
                           labelStatus={
                             <FieldStatusBadge
                               status={sectionStatuses.socials}
@@ -1973,7 +1948,6 @@ export default function EditCampaignPage() {
                           }
                           labelAction={renderEditButton("socials")}
                         />
-                        <FormMessage />
                       </FormItem>
                     )}
                   />

--- a/src/pages/NewCampaignPage.tsx
+++ b/src/pages/NewCampaignPage.tsx
@@ -33,6 +33,7 @@ import {
   WizardStep,
   type CreateCampaignResult,
   type CampaignFormData,
+  type CampaignWalrusStorageData,
 } from "@/features/campaigns/types/campaign";
 import {
   CampaignCreationModal,
@@ -76,6 +77,7 @@ import {
   newCampaignSchema,
   type NewCampaignFormData,
 } from "@/features/campaigns/schemas/newCampaignSchema";
+import { MIN_CAMPAIGN_SOCIAL_LINKS } from "@/features/campaigns/constants/socialPlatforms";
 import {
   DESCRIPTION_MAX_LENGTH,
   DESCRIPTION_WARNING_THRESHOLD,
@@ -176,6 +178,7 @@ export default function NewCampaignPage() {
     "endDate",
     "targetAmount",
     "walletAddress",
+    "socials",
     "campaignDetails",
     "termsAccepted",
   ];
@@ -251,9 +254,6 @@ export default function NewCampaignPage() {
     control: form.control,
     name: "campaignDetails",
   });
-  const campaignType = useWatch({ control: form.control, name: "campaignType" });
-  const startDate = useWatch({ control: form.control, name: "startDate" });
-  const endDate = useWatch({ control: form.control, name: "endDate" });
   const descriptionLength = (description ?? "").length;
   const isDescriptionNearLimit =
     DESCRIPTION_MAX_LENGTH - descriptionLength <= DESCRIPTION_WARNING_THRESHOLD;
@@ -262,34 +262,22 @@ export default function NewCampaignPage() {
   const debouncedCoverImage = useDebounce(coverImage, 1000);
   const debouncedCampaignDetails = useDebounce(campaignDetails, 1000);
 
-  // Auto-estimate cost when debounced values or epochs change
+  // Auto-estimate cost when the Walrus-backed content changes.
   useEffect(() => {
-    // Only estimate if we have both required fields
-    if (!debouncedCoverImage || !debouncedCampaignDetails) {
+    if (!(debouncedCoverImage instanceof File) || !debouncedCampaignDetails) {
       return;
     }
 
-    try {
-      if (!campaignType?.trim()) {
-        return;
-      }
-      if (!startDate || !endDate) {
-        return;
-      }
-      const formValues = form.getValues();
-      const campaignFormData = transformNewCampaignFormData(formValues);
-      estimateCost({ formData: campaignFormData, epochs: selectedEpochs });
-    } catch (error) {
-      console.error("Error auto-estimating cost:", error);
-    }
+    const walrusFormData: CampaignWalrusStorageData = {
+      full_description: debouncedCampaignDetails,
+      cover_image: debouncedCoverImage,
+    };
+
+    estimateCost({ formData: walrusFormData, epochs: selectedEpochs });
   }, [
     debouncedCoverImage,
     debouncedCampaignDetails,
-    campaignType,
-    startDate,
-    endDate,
     estimateCost,
-    form,
     selectedEpochs,
   ]);
 
@@ -395,18 +383,22 @@ export default function NewCampaignPage() {
     setCertifyResult(null);
 
     const campaignFormData = transformNewCampaignFormData(data);
+    const walrusFormData: CampaignWalrusStorageData = {
+      full_description: campaignFormData.full_description,
+      cover_image: campaignFormData.cover_image,
+    };
     setFormData(campaignFormData);
     // Don't open modal yet - let estimation and preparation happen silently
 
     // Automatically estimate cost and prepare upload
     estimateCost(
-      { formData: campaignFormData, epochs: selectedEpochs },
+      { formData: walrusFormData, epochs: selectedEpochs },
       {
         onSuccess: () => {
           // Prepare Walrus upload
           walrus.prepare.mutate(
             {
-              formData: campaignFormData,
+              formData: walrusFormData,
               network: DEFAULT_NETWORK,
               storageEpochs: selectedEpochs,
             },
@@ -1005,8 +997,9 @@ export default function NewCampaignPage() {
                         name="socials"
                         render={() => (
                           <FormItem data-field-error="socials">
-                            <CampaignSocialsSection />
-                            <FormMessage />
+                            <CampaignSocialsSection
+                              minSocials={MIN_CAMPAIGN_SOCIAL_LINKS}
+                            />
                           </FormItem>
                         )}
                       />

--- a/src/services/campaign-transaction.ts
+++ b/src/services/campaign-transaction.ts
@@ -13,8 +13,9 @@ import type {
 } from "@/features/campaigns/types/campaign";
 import { DESCRIPTION_MAX_LENGTH } from "@/features/campaigns/constants/validation";
 import {
+  normalizeCampaignSocialsMetadataValue,
   serializeSocialLinks,
-  sanitizeSocialLinks,
+  sanitizeCampaignSocialLinks,
 } from "@/features/campaigns/utils/socials";
 import { getContractConfig, CLOCK_OBJECT_ID } from "@/shared/config/contracts";
 import { WALRUS_EPOCH_CONFIG } from "@/shared/config/networkConfig";
@@ -89,7 +90,9 @@ export function buildCreateCampaignTransaction(
   const tx = new Transaction();
 
   // Use provided epochs or fall back to network default
-  const networkKey = (network === "devnet" ? "devnet" : network) as keyof typeof WALRUS_EPOCH_CONFIG;
+  const networkKey = (
+    network === "devnet" ? "devnet" : network
+  ) as keyof typeof WALRUS_EPOCH_CONFIG;
   const epochConfig = WALRUS_EPOCH_CONFIG[networkKey];
   const minEpochs = epochConfig.minEpochs ?? 1;
   const requestedEpochs =
@@ -262,10 +265,12 @@ export function buildUpdateCampaignMetadataTransaction(
   const values: string[] = [];
 
   Object.entries(patch).forEach(([key, value]) => {
+    let normalizedValue = value;
+
     if (
       key === "funding_goal" ||
       key === "recipient_address" ||
-      value === undefined
+      normalizedValue === undefined
     ) {
       if (key === "funding_goal" || key === "recipient_address") {
         console.warn(
@@ -275,8 +280,12 @@ export function buildUpdateCampaignMetadataTransaction(
       return;
     }
 
+    if (key === "socials_json") {
+      normalizedValue = normalizeCampaignSocialsMetadataValue(normalizedValue);
+    }
+
     keys.push(key);
-    values.push(value);
+    values.push(normalizedValue);
   });
 
   if (keys.length !== values.length) {
@@ -319,11 +328,8 @@ export function prepareMetadataVectors(
     cover_image_id: "cover.jpg", // Standard identifier in the Quilt
   };
 
-  const socials = sanitizeSocialLinks(formData.socials ?? []);
-
-  if (socials.length > 0) {
-    metadata.socials_json = serializeSocialLinks(socials);
-  }
+  const socials = sanitizeCampaignSocialLinks(formData.socials ?? []);
+  metadata.socials_json = serializeSocialLinks(socials);
 
   // Convert metadata object to parallel arrays
   const keys = Object.keys(metadata);
@@ -526,7 +532,7 @@ export function extractCampaignIdFromEffects(
     // objectChanges is at the top level of the result object
     const objectChanges = getObjectChanges(result);
 
-  const campaignType = `${packageId}::campaign::Campaign`;
+    const campaignType = `${packageId}::campaign::Campaign`;
 
     const campaignChange = objectChanges.find(
       (change) =>
@@ -647,7 +653,10 @@ export function validateCampaignFormData(formData: CampaignFormData): void {
   }
 
   // Recipient address validation
-  if (!formData.recipient_address || formData.recipient_address.trim().length === 0) {
+  if (
+    !formData.recipient_address ||
+    formData.recipient_address.trim().length === 0
+  ) {
     throw new Error("Recipient address is required");
   }
   if (!/^0x[a-fA-F0-9]+$/.test(formData.recipient_address)) {
@@ -669,7 +678,10 @@ export function validateCampaignFormData(formData: CampaignFormData): void {
   }
 
   // Policy preset validation
-  if (!formData.policyPresetName || formData.policyPresetName.trim().length === 0) {
+  if (
+    !formData.policyPresetName ||
+    formData.policyPresetName.trim().length === 0
+  ) {
     throw new Error("Policy preset must be selected.");
   }
 }

--- a/src/services/walrus.ts
+++ b/src/services/walrus.ts
@@ -16,7 +16,7 @@ import {
   WalrusUploadError,
   type WalrusUploadResult,
   type StorageCostEstimate,
-  type CampaignFormData,
+  type CampaignWalrusStorageData,
 } from "@/features/campaigns/types/campaign";
 import type { CampaignUpdateStorageData } from "@/features/campaigns/types/campaignUpdate";
 import { getContractConfig } from "@/shared/config/contracts";
@@ -251,7 +251,7 @@ export function createWalrusClient(
  * Stores Lexical editor state (JSON) and cover image - React app handles rendering
  */
 export async function prepareCampaignFiles(
-  formData: CampaignFormData,
+  formData: CampaignWalrusStorageData,
 ): Promise<WalrusFile[]> {
   console.log("\n=== PREPARING WALRUS FILES ===");
   const files: WalrusFile[] = [];
@@ -282,7 +282,11 @@ export async function prepareCampaignFiles(
   files.push(coverImageFile);
   console.log("File 2: cover.jpg -", coverImageBuffer.byteLength, "bytes");
   console.log("Total files:", files.length);
-  console.log("Total size:", descriptionBytes.length + coverImageBuffer.byteLength, "bytes");
+  console.log(
+    "Total size:",
+    descriptionBytes.length + coverImageBuffer.byteLength,
+    "bytes",
+  );
   console.log("==============================\n");
 
   return files;
@@ -304,7 +308,9 @@ export async function prepareCampaignUpdateFiles(
     serializedContent.trim().length === 0 ||
     plainTextContent.length === 0
   ) {
-    throw new WalrusUploadError("Update content is empty. Please add content before uploading.");
+    throw new WalrusUploadError(
+      "Update content is empty. Please add content before uploading.",
+    );
   }
 
   const files: WalrusFile[] = [];
@@ -504,7 +510,7 @@ export async function getUploadedFilesInfo(
 
     // Get the blob ID from the first file (they're all in the same Quilt)
     const blobId = uploadedFiles[0].blobId;
-    const blobObject = uploadedFiles[0].blobObject?.id?.id || '';
+    const blobObject = uploadedFiles[0].blobObject?.id?.id || "";
 
     console.log("\n=== WALRUS UPLOAD COMPLETE ===");
     console.log("Blob ID:", blobId);
@@ -519,7 +525,9 @@ export async function getUploadedFilesInfo(
     );
 
     console.log("Files uploaded:");
-    fileSizes.forEach(f => console.log(`  - ${f.identifier}: ${f.size} bytes`));
+    fileSizes.forEach((f) =>
+      console.log(`  - ${f.identifier}: ${f.size} bytes`),
+    );
 
     const totalSize = fileSizes.reduce((sum, file) => sum + file.size, 0);
     let cost = "N/A";
@@ -534,7 +542,10 @@ export async function getUploadedFilesInfo(
       );
       cost = formatTokenAmountFromNumber(costBreakdown.subsidizedTotalCost);
     } catch (costError) {
-      console.warn("Failed to estimate upload cost after certification:", costError);
+      console.warn(
+        "Failed to estimate upload cost after certification:",
+        costError,
+      );
     }
 
     console.log("Total size:", totalSize, "bytes");
@@ -566,7 +577,7 @@ export async function getUploadedFilesInfo(
 export async function calculateStorageCost(
   suiClient: SuiClient,
   network: SupportedNetwork,
-  formData: CampaignFormData,
+  formData: CampaignWalrusStorageData,
   epochs?: number,
 ): Promise<StorageCostEstimate> {
   const files = await prepareCampaignFiles(formData);


### PR DESCRIPTION
## Summary
- enforce a minimum of 2 valid social links for campaigns on create and edit, and validate campaign social metadata before writing it on-chain
- improve the campaign socials UI so the helper text reflects valid completed links, highlights the required state clearly, and prevents removing rows below the configured minimum on campaign forms
- keep Walrus-backed edit sections locked until existing blob content is actually resolved, and decouple Walrus estimation/upload payloads from Sui-only campaign metadata such as socials

## Testing
- pnpm lint (passes with one pre-existing warning in src/features/campaigns/components/CampaignContributionsTable.tsx:236)
- pnpm build

## Notes
- existing campaigns with fewer than 2 social links are now intentionally blocked from saving edits until they add enough valid links, matching the requested behavior
- Walrus cost estimation now depends only on the Walrus payload (description.json and cover.jpg), so social-link validation no longer interferes with storage estimation
